### PR TITLE
Fix character device indicator to be "cd"

### DIFF
--- a/lib/File/LsColor.pm
+++ b/lib/File/LsColor.pm
@@ -309,7 +309,7 @@ sub ls_color {
       -S $real_file and $ext = 'so'; # socket
       -p $real_file and $ext = 'pi'; # fifo, pipe
       -b $real_file and $ext = 'bd'; # block device
-      -c $real_file and $ext = 'ca'; # character special file
+      -c $real_file and $ext = 'cd'; # character special file
 
 # special case for directories that we can't stat, but we can still safely
 # assume that they are in fact dirs.


### PR DESCRIPTION
The character device indicator is "cd", not "ca" (the latter indicates *capabilities*). See https://github.com/coreutils/coreutils/blob/b1ac4786537bb0e414ba09f3f11430bd9317c96d/src/ls.c#L621